### PR TITLE
Otel Collector와 Grafana Loki 구성

### DIFF
--- a/app-b/src/main/java/com/example/opentelemetrypoc/HelloController.java
+++ b/app-b/src/main/java/com/example/opentelemetrypoc/HelloController.java
@@ -1,10 +1,12 @@
 package com.example.opentelemetrypoc;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Slf4j
 public class HelloController {
 
   @Value("${spring.application.name:not-set}")
@@ -12,11 +14,13 @@ public class HelloController {
 
   @GetMapping("say-hello")
   String sayHello1() {
+    log.info("{} called", serviceName);
     return "Hello I am " + serviceName;
   }
 
   @GetMapping("app-b/say-hello")
   String sayHello2() {
+    log.info("{} called", serviceName);
     return "Hello I am " + serviceName;
   }
 }

--- a/app-c/src/main/java/com/example/opentelemetrypoc/HelloController.java
+++ b/app-c/src/main/java/com/example/opentelemetrypoc/HelloController.java
@@ -1,10 +1,12 @@
 package com.example.opentelemetrypoc;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Slf4j
 public class HelloController {
 
   @Value("${spring.application.name:not-set}")
@@ -12,11 +14,13 @@ public class HelloController {
 
   @GetMapping("say-hello")
   String sayHello1() {
+    log.info("{} called", serviceName);
     return "Hello I am " + serviceName;
   }
 
   @GetMapping("app-c/say-hello")
   String sayHello2() {
+    log.info("{} called", serviceName);
     return "Hello I am " + serviceName;
   }
 }

--- a/helmValuesFiles/lokiValues.yaml
+++ b/helmValuesFiles/lokiValues.yaml
@@ -1,0 +1,12 @@
+loki:
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: 'filesystem'
+singleBinary:
+  replicas: 1
+
+backend:
+  persistence:
+    size: 1Gi
+

--- a/k8s/app-a.yaml
+++ b/k8s/app-a.yaml
@@ -42,14 +42,27 @@ spec:
           value: "8080"
         - name: JAVA_TOOL_OPTIONS
           value: "-javaagent:/usr/local/tomcat/lib/opentelemetry-javaagent.jar"
+        - name: OTEL_JAVAAGENT_ENABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "false"
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: "grpc"
+        - name: OTEL_SERVICE_NAME
+          value: "app-a"
+        - name: OTEL_TRACES_EXPORTER
+          value: none # otlp or none or logging
+        - name: OTEL_LOGS_EXPORTER
+          value: otlp # otlp or none or logging
+        - name: OTEL_METRICS_EXPORTER
+          value: none # otlp or none or logging
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://otel-collector:4317"
+#        - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+#          value: "http://otel-collector:4317"
         - name: OTEL_JAVAAGENT_LOGGING
           value: application
-        - name: OTEL_TRACES_EXPORTER
-          value: logging
-        - name: OTEL_METRICS_EXPORTER
-          value: none
-        - name: OTEL_LOGS_EXPORTER
-          value: logging
+
         resources:
           requests:
             cpu: 200m

--- a/k8s/app-a.yaml
+++ b/k8s/app-a.yaml
@@ -58,11 +58,8 @@ spec:
           value: none # otlp or none or logging
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "http://otel-collector:4317"
-#        - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-#          value: "http://otel-collector:4317"
         - name: OTEL_JAVAAGENT_LOGGING
           value: application
-
         resources:
           requests:
             cpu: 200m

--- a/k8s/app-a.yaml
+++ b/k8s/app-a.yaml
@@ -42,6 +42,14 @@ spec:
           value: "8080"
         - name: JAVA_TOOL_OPTIONS
           value: "-javaagent:/usr/local/tomcat/lib/opentelemetry-javaagent.jar"
+        - name: OTEL_JAVAAGENT_LOGGING
+          value: application
+        - name: OTEL_TRACES_EXPORTER
+          value: logging
+        - name: OTEL_METRICS_EXPORTER
+          value: none
+        - name: OTEL_LOGS_EXPORTER
+          value: logging
         resources:
           requests:
             cpu: 200m

--- a/k8s/app-b.yaml
+++ b/k8s/app-b.yaml
@@ -42,6 +42,24 @@ spec:
           value: "8080"
         - name: JAVA_TOOL_OPTIONS
           value: "-javaagent:/usr/local/tomcat/lib/opentelemetry-javaagent.jar"
+        - name: OTEL_JAVAAGENT_ENABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "false"
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: "grpc"
+        - name: OTEL_SERVICE_NAME
+          value: "app-b"
+        - name: OTEL_TRACES_EXPORTER
+          value: none # otlp or none or logging
+        - name: OTEL_LOGS_EXPORTER
+          value: otlp # otlp or none or logging
+        - name: OTEL_METRICS_EXPORTER
+          value: none # otlp or none or logging
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://otel-collector:4317"
+        - name: OTEL_JAVAAGENT_LOGGING
+          value: application
         resources:
           requests:
             cpu: 200m

--- a/k8s/app-c.yaml
+++ b/k8s/app-c.yaml
@@ -42,6 +42,24 @@ spec:
           value: "8080"
         - name: JAVA_TOOL_OPTIONS
           value: "-javaagent:/usr/local/tomcat/lib/opentelemetry-javaagent.jar"
+        - name: OTEL_JAVAAGENT_ENABLED
+          value: "true"
+        - name: OTEL_SDK_DISABLED
+          value: "false"
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: "grpc"
+        - name: OTEL_SERVICE_NAME
+          value: "app-c"
+        - name: OTEL_TRACES_EXPORTER
+          value: none # otlp or none or logging
+        - name: OTEL_LOGS_EXPORTER
+          value: otlp # otlp or none or logging
+        - name: OTEL_METRICS_EXPORTER
+          value: none # otlp or none or logging
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://otel-collector:4317"
+        - name: OTEL_JAVAAGENT_LOGGING
+          value: application
         resources:
           requests:
             cpu: 200m

--- a/k8s/grafana.yaml
+++ b/k8s/grafana.yaml
@@ -85,6 +85,7 @@ spec:
               name: grafana-pv
             - mountPath: /etc/grafana/provisioning/datasources/ds.yaml
               name: data-source
+              subPath: ds.yaml
       volumes:
         - name: grafana-pv
 #          persistentVolumeClaim:

--- a/k8s/grafana.yaml
+++ b/k8s/grafana.yaml
@@ -1,0 +1,109 @@
+#---
+#apiVersion: v1
+#kind: PersistentVolumeClaim
+#metadata:
+#  name: grafana-pvc
+#spec:
+#  accessModes:
+#    - ReadWriteOnce
+#  resources:
+#    requests:
+#      storage: 1Gi
+#---
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: data-source
+data:
+  ds.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki:3100
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      securityContext:
+        fsGroup: 472
+        supplementalGroups:
+          - 0
+      containers:
+        - name: grafana
+          image: grafana/grafana:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: GF_AUTH_DISABLE_LOGIN_FORM
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: "Admin"
+          ports:
+            - containerPort: 3000
+              name: http-grafana
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /robots.txt
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3000
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 750Mi
+          volumeMounts:
+            - mountPath: /var/lib/grafana
+              name: grafana-pv
+            - mountPath: /etc/grafana/provisioning/datasources/ds.yaml
+              name: data-source
+      volumes:
+        - name: grafana-pv
+#          persistentVolumeClaim:
+#            claimName: grafana-pvc
+          emptyDir: {}
+        - name: data-source
+          configMap:
+            name: data-source
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: http-grafana
+      nodePort: 30008
+  selector:
+    app: grafana
+  type: NodePort

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -35,6 +35,13 @@ spec:
                 name: app-a
                 port:
                   number: 8080
+          - path: /loki
+            pathType: Prefix
+            backend:
+              service:
+                name: loki-gateway
+                port:
+                  number: 80
 ---
 ## 외부 노출을 위한 NodePort Service
 apiVersion: v1
@@ -52,3 +59,5 @@ spec:
     - port: 80
       targetPort: 80
       nodePort: 30007 #(default: 30000-32767)
+
+---

--- a/k8s/lokiManifests.yaml
+++ b/k8s/lokiManifests.yaml
@@ -1,0 +1,1113 @@
+---
+# Source: loki/charts/grafana-agent-operator/templates/operator-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-grafana-agent-operator
+  labels:
+    app.kubernetes.io/name: grafana-agent-operator
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: operator
+    helm.sh/chart: grafana-agent-operator-0.2.16
+    app.kubernetes.io/version: "0.34.1"
+---
+# Source: loki/templates/loki-canary/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-canary
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: canary
+automountServiceAccountToken: true
+---
+# Source: loki/templates/monitoring/grafana-agent.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-grafana-agent
+  namespace: default
+---
+# Source: loki/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: loki/templates/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.yaml: |
+    
+    auth_enabled: false
+    common:
+      compactor_address: 'loki'
+      path_prefix: /var/loki
+      replication_factor: 1
+      storage:
+        filesystem:
+          chunks_directory: /var/loki/chunks
+          rules_directory: /var/loki/rules
+    frontend:
+      scheduler_address: ""
+    frontend_worker:
+      scheduler_address: ""
+    index_gateway:
+      mode: ring
+    limits_config:
+      enforce_metric_name: false
+      max_cache_freshness_per_query: 10m
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+      split_queries_by_interval: 15m
+    memberlist:
+      join_members:
+        - loki-memberlist
+    query_range:
+      align_queries_with_step: true
+    ruler:
+      storage:
+        type: local
+    runtime_config:
+      file: /etc/loki/runtime-config/runtime-config.yaml
+    schema_config:
+      configs:
+        - from: "2022-01-11"
+          index:
+            period: 24h
+            prefix: loki_index_
+          object_store: filesystem
+          schema: v12
+          store: boltdb-shipper
+    server:
+      grpc_listen_port: 9095
+      http_listen_port: 3100
+#    storage_config:
+#      hedging:
+#        at: 250ms
+#        max_per_second: 20
+#        up_to: 3
+---
+# Source: loki/templates/gateway/configmap-gateway.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: gateway
+data:
+  nginx.conf: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+    
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+    
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+    
+      client_max_body_size  4M;
+    
+      proxy_read_timeout    600; ## 10 minutes
+      proxy_send_timeout    600;
+      proxy_connect_timeout 600;
+    
+      proxy_http_version    1.1;
+    
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+            '"$request" $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+    
+      sendfile     on;
+      tcp_nopush   on;
+      resolver kube-dns.kube-system.svc.cluster.local.;
+    
+    
+      server {
+        listen             8080;
+        listen             [::]:8080;
+    
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+    
+    
+        # Distributor
+        location = /api/prom/push {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1/push {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /distributor/ring {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+    
+        # Ingester
+        location = /flush {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location ^~ /ingester/ {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /ingester {
+          internal;        # to suppress 301
+        }
+    
+        # Ring
+        location = /ring {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+    
+        # MemberListKV
+        location = /memberlist {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+    
+    
+        # Ruler
+        location = /ruler/ring {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /api/prom/rules {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location ^~ /api/prom/rules/ {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1/rules {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location ^~ /loki/api/v1/rules/ {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /prometheus/api/v1/alerts {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /prometheus/api/v1/rules {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+    
+        # Compactor
+        location = /compactor/ring {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1/delete {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1/cache/generation_numbers {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+    
+        # IndexGateway
+        location = /indexgateway/ring {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+    
+        # QueryScheduler
+        location = /scheduler/ring {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+    
+        # Config
+        location = /config {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+    
+    
+        # QueryFrontend, Querier
+        location = /api/prom/tail {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+        location = /loki/api/v1/tail {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+        location ^~ /api/prom/ {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /api/prom {
+          internal;        # to suppress 301
+        }
+        location ^~ /loki/api/v1/ {
+          proxy_pass       http://loki.default.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1 {
+          internal;        # to suppress 301
+        }
+      }
+    }
+---
+# Source: loki/templates/runtime-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-runtime
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  runtime-config.yaml: |
+    {}
+---
+# Source: loki/charts/grafana-agent-operator/templates/operator-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: loki-grafana-agent-operator
+  labels:
+    app.kubernetes.io/name: grafana-agent-operator
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: operator
+    helm.sh/chart: grafana-agent-operator-0.2.16
+    app.kubernetes.io/version: "0.34.1"
+rules:
+  - apiGroups: [monitoring.grafana.com]
+    resources:
+      - grafanaagents
+      - metricsinstances
+      - logsinstances
+      - podlogs
+      - integrations
+    verbs: [get, list, watch]
+  - apiGroups: [monitoring.grafana.com]
+    resources:
+      - grafanaagents/finalizers
+      - metricsinstances/finalizers
+      - logsinstances/finalizers
+      - podlogs/finalizers
+      - integrations/finalizers
+    verbs: [get, list, watch, update]
+  - apiGroups: [monitoring.coreos.com]
+    resources:
+      - podmonitors
+      - probes
+      - servicemonitors
+    verbs: [get, list, watch]
+  - apiGroups: [monitoring.coreos.com]
+    resources:
+      - podmonitors/finalizers
+      - probes/finalizers
+      - servicemonitors/finalizers
+    verbs: [get, list, watch, update]
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources:
+      - secrets
+      - services
+      - configmaps
+      - endpoints
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - daemonsets
+      - deployments
+    verbs: [get, list, watch, create, update, patch, delete]
+---
+# Source: loki/templates/monitoring/grafana-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: loki-grafana-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+    verbs:
+      - get
+---
+# Source: loki/charts/grafana-agent-operator/templates/operator-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: loki-grafana-agent-operator
+  labels:
+    app.kubernetes.io/name: grafana-agent-operator
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: operator
+    helm.sh/chart: grafana-agent-operator-0.2.16
+    app.kubernetes.io/version: "0.34.1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-grafana-agent-operator
+subjects:
+  - kind: ServiceAccount
+    name: loki-grafana-agent-operator
+    namespace: default
+---
+# Source: loki/templates/monitoring/grafana-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: loki-grafana-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-grafana-agent
+subjects:
+  - kind: ServiceAccount
+    name: loki-grafana-agent
+    namespace: default
+---
+# Source: loki/templates/gateway/service-gateway.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: gateway
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: gateway
+---
+# Source: loki/templates/loki-canary/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-canary
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: canary
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metrics
+      port: 3500
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: canary
+---
+# Source: loki/templates/service-memberlist.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-memberlist
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp
+      port: 7946
+      targetPort: http-memberlist
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/part-of: memberlist
+---
+# Source: loki/templates/single-binary/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-headless
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+    variant: headless
+    prometheus.io/service-monitor: "false"
+  annotations:
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+---
+# Source: loki/templates/single-binary/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: single-binary
+---
+# Source: loki/templates/loki-canary/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: loki-canary
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: canary
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/component: canary
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/component: canary
+    spec:
+      serviceAccountName: loki-canary
+      
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      containers:
+        - name: loki-canary
+          image: docker.io/grafana/loki-canary:2.9.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -addr=loki-gateway.default.svc.cluster.local.:80
+            - -labelname=pod
+            - -labelvalue=$(POD_NAME)
+            - -user=self-monitoring
+            - -tenant-id=self-monitoring
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - name: http-metrics
+              containerPort: 3500
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http-metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+---
+# Source: loki/charts/grafana-agent-operator/templates/operator-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki-grafana-agent-operator
+  labels:
+    app.kubernetes.io/name: grafana-agent-operator
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: operator
+    helm.sh/chart: grafana-agent-operator-0.2.16
+    app.kubernetes.io/version: "0.34.1"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent-operator
+      app.kubernetes.io/instance: loki
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent-operator
+        app.kubernetes.io/instance: loki
+    spec:
+      serviceAccountName: loki-grafana-agent-operator
+      containers:
+        - name: grafana-agent-operator
+          image: "docker.io/grafana/agent-operator:v0.34.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --kubelet-service=default/kubelet
+---
+# Source: loki/templates/gateway/deployment-gateway.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      annotations:
+        checksum/config: 06ebbaf081ebd466dfdc80b4b0e1b09361e564b4a7fe4d46efcbce340795e312
+      labels:
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/component: gateway
+    spec:
+      serviceAccountName: loki
+      enableServiceLinks: true
+      
+      securityContext:
+        fsGroup: 101
+        runAsGroup: 101
+        runAsNonRoot: true
+        runAsUser: 101
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.23-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx
+            - name: tmp
+              mountPath: /tmp
+            - name: docker-entrypoint-d-override
+              mountPath: /docker-entrypoint.d
+          resources:
+            {}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: loki
+                  app.kubernetes.io/instance: loki
+                  app.kubernetes.io/component: gateway
+              topologyKey: kubernetes.io/hostname
+
+      volumes:
+        - name: config
+          configMap:
+            name: loki-gateway
+        - name: tmp
+          emptyDir: {}
+        - name: docker-entrypoint-d-override
+          emptyDir: {}
+---
+# Source: loki/templates/single-binary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: default
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: single-binary
+    app.kubernetes.io/part-of: memberlist
+spec:
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: loki-headless
+  revisionHistoryLimit: 10
+  
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/component: single-binary
+  template:
+    metadata:
+      annotations:
+        checksum/config: 44c045ad0a0da07ffa7e8ceed2e7cbb0ab518a485e1101a5177c5865d7be37a2
+      labels:
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/component: single-binary
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      serviceAccountName: loki
+      automountServiceAccountToken: true
+      enableServiceLinks: true
+      
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: loki
+          image: docker.io/grafana/loki:2.9.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=all
+          ports:
+            - name: http-metrics
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: config
+              mountPath: /etc/loki/config
+            - name: runtime-config
+              mountPath: /etc/loki/runtime-config
+            - name: storage-tmp # <-- 테스트용도로 수정함, 휘발성
+              mountPath: /var/loki
+          resources:
+            {}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: loki
+                  app.kubernetes.io/instance: loki
+                  app.kubernetes.io/component: single-binary
+              topologyKey: kubernetes.io/hostname
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: loki
+            items:
+              - key: "config.yaml"
+                path: "config.yaml"
+        - name: runtime-config
+          configMap:
+            name: loki-runtime
+        - name: storage-tmp
+          emptyDir:
+            sizeLimit: 5Gi
+#  volumeClaimTemplates:
+#    - metadata:
+#        name: storage
+#      spec:
+#        accessModes:
+#          - ReadWriteOnce
+#        resources:
+#          requests:
+#            storage: "10Gi"
+---
+# Source: loki/templates/monitoring/grafana-agent.yaml
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: GrafanaAgent
+metadata:
+  name: loki
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  serviceAccountName: loki-grafana-agent
+  enableConfigReadAPI: false
+  
+  logs:
+    instanceSelector:
+      matchLabels:
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/instance: loki
+---
+# Source: loki/templates/monitoring/logs-instance.yaml
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: LogsInstance
+metadata:
+  name: loki
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  clients:
+    - url: http://loki.default.svc.cluster.local:3100/loki/api/v1/push
+      externalLabels:
+        cluster: loki
+      tenantId: "self-monitoring"
+
+  podLogsNamespaceSelector: {}
+
+  podLogsSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: loki
+---
+# Source: loki/templates/monitoring/pod-logs.yaml
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: PodLogs
+metadata:
+  name: loki
+  labels:
+    helm.sh/chart: loki-5.18.1
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/version: "2.9.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  pipelineStages:
+    - cri: { }
+  relabelings:
+    - sourceLabels:
+        - __meta_kubernetes_pod_node_name
+      targetLabel: __host__
+    - action: labelmap
+      regex: __meta_kubernetes_pod_label_(.+)
+    - action: replace
+      replacement: "$1"
+      separator: "-"
+      sourceLabels:
+        - __meta_kubernetes_pod_label_app_kubernetes_io_name
+        - __meta_kubernetes_pod_label_app_kubernetes_io_component
+      targetLabel: __service__
+    - action: replace
+      replacement: "$1"
+      separator: "/"
+      sourceLabels:
+        - __meta_kubernetes_namespace
+        - __service__
+      targetLabel: job
+    - action: replace
+      sourceLabels:
+        - __meta_kubernetes_pod_container_name
+      targetLabel: container
+    - replacement: "loki"
+      targetLabel: cluster
+  namespaceSelector:
+    matchNames:
+      - default
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: loki
+---
+# Source: loki/charts/grafana-agent-operator/templates/tests/test-grafanaagent.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent-test-sa
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+---
+# Source: loki/charts/grafana-agent-operator/templates/tests/test-grafanaagent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent-test-cr
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+    verbs:
+      - get
+---
+# Source: loki/charts/grafana-agent-operator/templates/tests/test-grafanaagent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent-test-crb
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent-test-cr
+subjects:
+  - kind: ServiceAccount
+    name: grafana-agent-test-sa
+    namespace: default
+---
+# Source: loki/charts/grafana-agent-operator/templates/tests/test-grafanaagent.yaml
+#apiVersion: v1
+#kind: Pod
+#metadata:
+#  name: grafana-agent-test-probe
+#  annotations:
+#    "helm.sh/hook": test
+#    "helm.sh/hook-weight": "1"
+#    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+#spec:
+#  containers:
+#    - name: busybox
+#      image: busybox
+#      command: ['wget']
+#      args:  ['grafana-agent-test-operated:8080/-/healthy']
+#  # Wait for GrafanaAgent CR
+#  initContainers:
+#    - name: sleep
+#      image: busybox
+#      command: ['sleep', '60']
+#  restartPolicy: Never
+---
+# Source: loki/templates/tests/test-canary.yaml
+#apiVersion: v1
+#kind: Pod
+#metadata:
+#  name: "loki-helm-test"
+#  namespace: default
+#  labels:
+#    helm.sh/chart: loki-5.18.1
+#    app.kubernetes.io/name: loki
+#    app.kubernetes.io/instance: loki
+#    app.kubernetes.io/version: "2.9.0"
+#    app.kubernetes.io/managed-by: Helm
+#    app.kubernetes.io/component: helm-test
+#  annotations:
+#    "helm.sh/hook": test
+#spec:
+#  containers:
+#    - name: loki-helm-test
+#      image: docker.io/grafana/loki-helm-test:latest
+#      env:
+#        - name: CANARY_PROMETHEUS_ADDRESS
+#          value: "http://prometheus:9090"
+#        - name: CANARY_TEST_TIMEOUT
+#          value: "1m"
+#      args:
+#        - -test.v
+#  restartPolicy: Never
+---
+# Source: loki/charts/grafana-agent-operator/templates/tests/test-grafanaagent.yaml
+#apiVersion: monitoring.grafana.com/v1alpha1
+#kind: GrafanaAgent
+#metadata:
+#  name: grafana-agent-test
+#  labels:
+#    app: grafana-agent-test
+#  annotations:
+#    "helm.sh/hook": test
+#    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+#spec:
+#  image: "docker.io/grafana/agent:v0.34.1"
+#  logLevel: info
+#  serviceAccountName: grafana-agent-test-sa
+#  metrics:
+#    instanceSelector:
+#      matchLabels:
+#        agent: grafana-agent-test
+---
+# Source: loki/charts/grafana-agent-operator/templates/tests/test-grafanaagent.yaml
+apiVersion: monitoring.grafana.com/v1alpha1
+kind: MetricsInstance
+metadata:
+  name: primary-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+  labels:
+    agent: grafana-agent-test
+spec: {}

--- a/k8s/otel-collector.yaml
+++ b/k8s/otel-collector.yaml
@@ -43,7 +43,7 @@ data:
       logging:
         verbosity: detailed
       loki:
-        endpoint: http://loki:3100/loki/api/v1/push
+        endpoint: http://loki-gateway:80/loki/api/v1/push
         default_labels_enabled:
           exporter: false
           job: true

--- a/k8s/otel-collector.yaml
+++ b/k8s/otel-collector.yaml
@@ -1,0 +1,138 @@
+# ref : https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/main/examples/k8s/otel-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-conf
+  labels:
+    app: opentelemetry
+    component: otel-collector-conf
+data:
+  otel-collector-config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+    processors:
+      batch:
+      memory_limiter:
+        # 80% of maximum memory up to 2G
+        limit_mib: 1500
+        # 25% of limit up to 2G
+        spike_limit_mib: 512
+        check_interval: 5s
+    extensions:
+      zpages: {}
+      memory_ballast:
+        # Memory Ballast size should be max 1/3 to 1/2 of memory.
+        size_mib: 683
+    exporters:
+      otlp:
+        endpoint: "http://someotlp.target.com:4317" # Replace with a real endpoint.
+        tls:
+          insecure: true
+      file:
+        path: ./test.log
+      logging:
+    service:
+      extensions: [zpages, memory_ballast]
+      pipelines:
+          logs:
+            receivers: [otlp]
+            processors: []
+            exporters: [logging]
+#        traces/1:
+#          receivers: [otlp]
+#          processors: [memory_limiter, batch]
+#          exporters: [otlp]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  ports:
+    - name: otlp-grpc # Default endpoint for OpenTelemetry gRPC receiver.
+      port: 4317
+      protocol: TCP
+      targetPort: 4317
+    - name: otlp-http # Default endpoint for OpenTelemetry HTTP receiver.
+      port: 4318
+      protocol: TCP
+      targetPort: 4318
+    - name: metrics # Default endpoint for querying metrics.
+      port: 8888
+  selector:
+    component: otel-collector
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  selector:
+    matchLabels:
+      app: opentelemetry
+      component: otel-collector
+  minReadySeconds: 5
+  progressDeadlineSeconds: 120
+  replicas: 1 #TODO - adjust this to your own requirements
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: otel-collector
+    spec:
+      containers:
+        - command:
+            - "/otelcol"
+            - "--config=/conf/otel-collector-config.yaml"
+          image: otel/opentelemetry-collector:0.84.0
+          name: otel-collector
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 200m
+              memory: 400Mi
+          ports:
+            - containerPort: 55679 # Default endpoint for ZPages.
+            - containerPort: 4317 # Default endpoint for OpenTelemetry receiver.
+            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+            - containerPort: 9411 # Default endpoint for Zipkin receiver.
+            - containerPort: 8888  # Default endpoint for querying metrics.
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+          volumeMounts:
+            - name: otel-collector-config-vol
+              mountPath: /conf
+      #        - name: otel-collector-secrets
+      #          mountPath: /secrets
+      volumes:
+        - configMap:
+            name: otel-collector-conf
+            items:
+              - key: otel-collector-config
+                path: otel-collector-config.yaml
+          name: otel-collector-config-vol
+#        - secret:
+#            name: otel-collector-secrets
+#            items:
+#              - key: cert.pem
+#                path: cert.pem
+#              - key: key.pem
+#                path: key.pem

--- a/k8s/otel-collector.yaml
+++ b/k8s/otel-collector.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: otel-collector-conf
+  name: otel-collector-config
   labels:
     app: opentelemetry
-    component: otel-collector-conf
+    component: otel-collector-config
 data:
-  otel-collector-config: |
+  config.yaml: |
     receivers:
       otlp:
         protocols:
@@ -16,6 +16,11 @@ data:
           http:
             endpoint: ${env:MY_POD_IP}:4318
     processors:
+      resource:
+        attributes:
+          - action: insert
+            key: loki.resource.labels
+            value: service.name
       batch:
       memory_limiter:
         # 80% of maximum memory up to 2G
@@ -36,13 +41,20 @@ data:
       file:
         path: ./test.log
       logging:
+        verbosity: detailed
+      loki:
+        endpoint: http://loki:3100/loki/api/v1/push
+        default_labels_enabled:
+          exporter: false
+          job: true
     service:
-      extensions: [zpages, memory_ballast]
+    #  extensions: [zpages, memory_ballast]
       pipelines:
           logs:
             receivers: [otlp]
-            processors: []
-            exporters: [logging]
+            processors: [resource]
+            exporters: [loki]
+    #        exporters: [logging, loki]
 #        traces/1:
 #          receivers: [otlp]
 #          processors: [memory_limiter, batch]
@@ -92,18 +104,26 @@ spec:
         component: otel-collector
     spec:
       containers:
-        - command:
-            - "/otelcol"
-            - "--config=/conf/otel-collector-config.yaml"
-          image: otel/opentelemetry-collector:0.84.0
-          name: otel-collector
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.84.0
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 200m
-              memory: 400Mi
+              memory: 200Mi
+          volumeMounts:
+            - mountPath: /var/log
+              name: varlog
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /etc/otelcol-contrib/config.yaml
+              name: data
+              subPath: config.yaml
+              readOnly: true
           ports:
             - containerPort: 55679 # Default endpoint for ZPages.
             - containerPort: 4317 # Default endpoint for OpenTelemetry receiver.
@@ -117,22 +137,15 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-          volumeMounts:
-            - name: otel-collector-config-vol
-              mountPath: /conf
-      #        - name: otel-collector-secrets
-      #          mountPath: /secrets
+      terminationGracePeriodSeconds: 0
       volumes:
-        - configMap:
-            name: otel-collector-conf
-            items:
-              - key: otel-collector-config
-                path: otel-collector-config.yaml
-          name: otel-collector-config-vol
-#        - secret:
-#            name: otel-collector-secrets
-#            items:
-#              - key: cert.pem
-#                path: cert.pem
-#              - key: key.pem
-#                path: key.pem
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: data
+          configMap:
+            name: otel-collector-config
+

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -21,6 +21,16 @@ build:
 manifests:
   rawYaml:
     - k8s/**.yaml
+
+#deploy:
+#  helm:
+#    releases:
+#      - name: loki
+#        repo: https://grafana.github.io/helm-charts
+#        remoteChart: loki
+#        valuesFiles: [helmValuesFiles/lokiValues.yaml]
+#        skipTests: true
+
 #deploy:
 #  kubectl:
 #    mani


### PR DESCRIPTION
## 코드 변경 이유
- [X] 신규Feature 추가
- [X] 기존Feature 변경
- 목적 : Otel Collector의 기본 동작 확인

## 변경 사항
- Otel Collector의 단순 log 수집 기능 확인
- app-a, app-c, app-d의 로그 -> Otel Collector ->  loki -> grafana 로 이동
- grafana ( node port 30008 ) 을 통해 3 개 app의 로그를 조회 가능하다

## 참고사항(To Reviewers)
- tracing관련은 아직 미적용

## Related Issue and Link